### PR TITLE
Change Digest::SHA2 -> OpenSSL::Digest.SHA256.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ require 'mysql'
 require './helpers/email.rb'
 require './helpers/compute_task_keyspace.rb'
 require 'data_mapper'
+require 'openssl'
 
 require_relative 'jobs/init'
 # require_relative 'helpers/init'
@@ -613,7 +614,7 @@ def upgrade_to_v070(user, password, host, database)
       rule_file.name = name
       rule_file.path = path_file
       rule_file.size = 0
-      rule_file.checksum = Digest::SHA2.hexdigest(File.read(path_file))
+      rule_file.checksum = OpenSSL::Digest::SHA256.hexdigest(File.read(path_file))
       rule_file.save
 
     end

--- a/helpers/dynamicWordlists.rb
+++ b/helpers/dynamicWordlists.rb
@@ -23,7 +23,7 @@ def updateDynamicWordlist(wordlist_id)
       f.puts entry['plaintext']
     end
   end
-  wordlist.checksum = Digest::SHA2.hexdigest(File.read(file))
+  wordlist.checksum = OpenSSL::Digest::SHA256.hexdigest(File.read(file))
   size = File.foreach(file).inject(0) do |c|
     c + 1
   end

--- a/jobs/ruleImporter.rb
+++ b/jobs/ruleImporter.rb
@@ -28,7 +28,7 @@ module RuleImporter
         rule_file.name = name
         rule_file.path = path_file
         rule_file.size = 0
-        rule_file.checksum = Digest::SHA2.hexdigest(File.read(path_file))
+        rule_file.checksum = OpenSSL::Digest::SHA256.hexdigest(File.read(path_file))
         rule_file.save
 
       end

--- a/jobs/wordlistChecksum.rb
+++ b/jobs/wordlistChecksum.rb
@@ -19,7 +19,7 @@ module WordlistChecksum
     @wordlist.each do |wl|
       # generate checksum
       logger_wordlistchecksum.info('generating checksum for: ' + wl.path.to_s)
-      checksum = Digest::SHA2.hexdigest(File.read(wl.path))
+      checksum = OpenSSL::Digest::SHA256.hexdigest(File.read(wl.path))
 
       # save checksum to database
       wl.checksum = checksum

--- a/routes/rules.rb
+++ b/routes/rules.rb
@@ -66,7 +66,7 @@ post '/rules/new' do
     f.puts(rules_array)
   end
 
-  rules_file.checksum = Digest::SHA2.hexdigest(File.read(rules_file_path_name))
+  rules_file.checksum = OpenSSL::Digest::SHA256.hexdigest(File.read(rules_file_path_name))
   rules_file.save
 
   flash[:success] = 'Successfully created new rule.'
@@ -134,7 +134,7 @@ post '/rules/save/:id' do
     c + 1
   end
   rules_file.size = size
-  rules_file.checksum = Digest::SHA2.hexdigest(File.read(rules_file.path))
+  rules_file.checksum = OpenSSL::Digest::SHA256.hexdigest(File.read(rules_file.path))
   rules_file.save
 
   flash[:success] = 'Successfully uploaded rules file.'


### PR DESCRIPTION
Since the Ruby/digest gem was removed from rubygems and OpenSSL::Digest
is included in Ruby this can be used instead. This should ensure there are no hidden errors and will resolve #419. 

Digest::SHA2 == OpenSSL::Digest::SHA256.
irb(main):004:0> Digest::SHA2.hexdigest('test')
=> "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
irb(main):005:0> OpenSSL::Digest::SHA256.hexdigest('test')
=> "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"